### PR TITLE
Lower MIN_ICUSD_AMOUNT to 0.1 icUSD

### DIFF
--- a/src/rumi_protocol_backend/src/lib.rs
+++ b/src/rumi_protocol_backend/src/lib.rs
@@ -47,7 +47,7 @@ pub const E8S: u64 = 100_000_000;
 
 pub const MIN_LIQUIDITY_AMOUNT: ICUSD = ICUSD::new(1_000_000_000);
 pub const MIN_ICP_AMOUNT: ICP = ICP::new(100_000);  // Instead of MIN_CKBTC_AMOUNT
-pub const MIN_ICUSD_AMOUNT: ICUSD = ICUSD::new(500_000_000); // 5 icUSD (reduced from 10)
+pub const MIN_ICUSD_AMOUNT: ICUSD = ICUSD::new(10_000_000); // 0.1 icUSD
 
 // Update collateral ratios per whitepaper
 pub const RECOVERY_COLLATERAL_RATIO: Ratio = Ratio::new(dec!(1.5));  // 150%


### PR DESCRIPTION
### Summary
Reduce the minimum icUSD amount from 5 to 0.1.
- File: `src/rumi_protocol_backend/lib.rs`
- Before: `MIN_ICUSD_AMOUNT = ICUSD::new(500_000_000)`  // 5 icUSD
- After:  `MIN_ICUSD_AMOUNT = ICUSD::new(10_000_000)`   // 0.1 icUSD
- E8S = 100_000_000

### Motivation
Enable small test mints and smoother onboarding. This lets users try the system with tiny amounts and supports micropayment use cases.

### Scope
This constant is used in three flows:
- `borrow_from_vault` (minimum mint)
- `repay_to_vault`   (minimum repay)
- `redeem_icp`       (minimum redeem)

No Candid interface changes. No data migration.

### Risks and checks
- Rounding and fees: confirm that the borrowing fee on 0.1 icUSD does not round to zero in a way that breaks math.
- Ledger fees: verify 0.1 icUSD transfers and ICP redemptions still clear with current fee settings.
- Dust: confirm accounting and UI avoid creating unpayable dust.

### QA
- Borrow 0.09 icUSD → expect `AmountTooLow` with minimum 0.1.
- Borrow 0.1 icUSD → succeeds, mints `0.1 - fee`.
- Repay 0.1 icUSD → succeeds; 0.09 rejected.
- Redeem 0.1 icUSD → succeeds; 0.09 rejected.
- Events and logs show correct values; no panics.

### Follow up (optional)
If we want different minimums for mint vs repay vs redeem, split this into: `MIN_BORROW_ICUSD_AMOUNT`, `MIN_REPAY_ICUSD_AMOUNT`, `MIN_REDEEM_ICUSD_AMOUNT`.

### Tasks
- [ ] Update constant
- [ ] Update UI validation and copy that mentions the minimum
- [ ] Deploy backend canister